### PR TITLE
Return the masked email or address to caller

### DIFF
--- a/src/http/DescopeClient.swift
+++ b/src/http/DescopeClient.swift
@@ -11,21 +11,21 @@ class DescopeClient: HTTPClient {
     
     // MARK: - OTP
     
-    func otpSignUp(with method: DeliveryMethod, loginId: String, user: User) async throws {
-        try await post("otp/signup/\(method.rawValue)", body: [
+    func otpSignUp(with method: DeliveryMethod, loginId: String, user: User) async throws -> MaskedAddress {
+        return try await post("otp/signup/\(method.rawValue)", body: [
             "loginId": loginId,
             "user": user.dictValue,
         ])
     }
     
-    func otpSignIn(with method: DeliveryMethod, loginId: String) async throws {
-        try await post("otp/signin/\(method.rawValue)", body: [
+    func otpSignIn(with method: DeliveryMethod, loginId: String) async throws -> MaskedAddress {
+        return try await post("otp/signin/\(method.rawValue)", body: [
             "loginId": loginId
         ])
     }
     
-    func otpSignUpIn(with method: DeliveryMethod, loginId: String) async throws {
-        try await post("otp/signup-in/\(method.rawValue)", body: [
+    func otpSignUpIn(with method: DeliveryMethod, loginId: String) async throws -> MaskedAddress{
+        return try await post("otp/signup-in/\(method.rawValue)", body: [
             "loginId": loginId
         ])
     }
@@ -37,16 +37,16 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func otpUpdateEmail(_ email: String, loginId: String, refreshJwt: String) async throws {
-        try await post("otp/update/email", headers: authorization(with: refreshJwt), body: [
+    func otpUpdateEmail(_ email: String, loginId: String, refreshJwt: String) async throws -> MaskedAddress{
+        return try await post("otp/update/email", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
             "email": email,
         ])
     }
     
-    func otpUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws {
+    func otpUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws -> MaskedAddress{
         try method.ensurePhoneMethod()
-        try await post("otp/update/phone/\(method.rawValue)", headers: authorization(with: refreshJwt), body: [
+        return try await post("otp/update/phone/\(method.rawValue)", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
             "phone": phone,
         ])
@@ -99,23 +99,23 @@ class DescopeClient: HTTPClient {
     
     // MARK: - Magic Link
     
-    func magicLinkSignUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws {
-        try await post("magiclink/signup/\(method.rawValue)", body: [
+    func magicLinkSignUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws -> MaskedAddress{
+        return try await post("magiclink/signup/\(method.rawValue)", body: [
             "loginId": loginId,
             "user": user.dictValue,
             "uri": uri,
         ])
     }
     
-    func magicLinkSignIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws {
-        try await post("magiclink/signin/\(method.rawValue)", body: [
+    func magicLinkSignIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> MaskedAddress{
+        return try await post("magiclink/signin/\(method.rawValue)", body: [
             "loginId": loginId,
             "uri": uri,
         ])
     }
     
-    func magicLinkSignUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws {
-        try await post("magiclink/signup-in/\(method.rawValue)", body: [
+    func magicLinkSignUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> MaskedAddress{
+        return try await post("magiclink/signup-in/\(method.rawValue)", body: [
             "loginId": loginId,
             "uri": uri,
         ])
@@ -127,17 +127,17 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func magicLinkUpdateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws {
-        try await post("magiclink/update/email", headers: authorization(with: refreshJwt), body: [
+    func magicLinkUpdateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> MaskedAddress{
+        return try await post("magiclink/update/email", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
             "email": email,
             "uri": uri,
         ])
     }
     
-    func magicLinkUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws {
+    func magicLinkUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws -> MaskedAddress{
         try method.ensurePhoneMethod()
-        try await post("magiclink/update/phone/\(method.rawValue)", headers: authorization(with: refreshJwt), body: [
+        return try await post("magiclink/update/phone/\(method.rawValue)", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
             "phone": phone,
             "uri": uri,
@@ -149,6 +149,7 @@ class DescopeClient: HTTPClient {
     struct EnchantedLinkResponse: JSONResponse {
         var linkId: String
         var pendingRef: String
+        var maskedEmail: String
     }
     
     func enchantedLinkSignUp(loginId: String, user: User, uri: String?) async throws -> EnchantedLinkResponse {
@@ -277,6 +278,11 @@ class DescopeClient: HTTPClient {
         var verifiedEmail: Bool = false
         var phone: String?
         var verifiedPhone: Bool = false
+    }
+    
+    struct MaskedAddress: JSONResponse {
+        var maskedEmail: String?
+        var maskedPhone: String?
     }
     
     // MARK: - Internal

--- a/src/http/DescopeClient.swift
+++ b/src/http/DescopeClient.swift
@@ -24,7 +24,7 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func otpSignUpIn(with method: DeliveryMethod, loginId: String) async throws -> MaskedAddress{
+    func otpSignUpIn(with method: DeliveryMethod, loginId: String) async throws -> MaskedAddress {
         return try await post("otp/signup-in/\(method.rawValue)", body: [
             "loginId": loginId
         ])
@@ -37,14 +37,14 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func otpUpdateEmail(_ email: String, loginId: String, refreshJwt: String) async throws -> MaskedAddress{
+    func otpUpdateEmail(_ email: String, loginId: String, refreshJwt: String) async throws -> MaskedAddress {
         return try await post("otp/update/email", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
             "email": email,
         ])
     }
     
-    func otpUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws -> MaskedAddress{
+    func otpUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws -> MaskedAddress {
         try method.ensurePhoneMethod()
         return try await post("otp/update/phone/\(method.rawValue)", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
@@ -99,7 +99,7 @@ class DescopeClient: HTTPClient {
     
     // MARK: - Magic Link
     
-    func magicLinkSignUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws -> MaskedAddress{
+    func magicLinkSignUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws -> MaskedAddress {
         return try await post("magiclink/signup/\(method.rawValue)", body: [
             "loginId": loginId,
             "user": user.dictValue,
@@ -107,14 +107,14 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func magicLinkSignIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> MaskedAddress{
+    func magicLinkSignIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> MaskedAddress {
         return try await post("magiclink/signin/\(method.rawValue)", body: [
             "loginId": loginId,
             "uri": uri,
         ])
     }
     
-    func magicLinkSignUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> MaskedAddress{
+    func magicLinkSignUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> MaskedAddress {
         return try await post("magiclink/signup-in/\(method.rawValue)", body: [
             "loginId": loginId,
             "uri": uri,
@@ -127,7 +127,7 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func magicLinkUpdateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> MaskedAddress{
+    func magicLinkUpdateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> MaskedAddress {
         return try await post("magiclink/update/email", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,
             "email": email,
@@ -135,7 +135,7 @@ class DescopeClient: HTTPClient {
         ])
     }
     
-    func magicLinkUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws -> MaskedAddress{
+    func magicLinkUpdatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws -> MaskedAddress {
         try method.ensurePhoneMethod()
         return try await post("magiclink/update/phone/\(method.rawValue)", headers: authorization(with: refreshJwt), body: [
             "loginId": loginId,

--- a/src/routes/EnchantedLink.swift
+++ b/src/routes/EnchantedLink.swift
@@ -62,6 +62,6 @@ class EnchantedLink: DescopeEnchantedLink {
 
 private extension DescopeClient.EnchantedLinkResponse {
     func convert() -> EnchantedLinkResponse {
-        return EnchantedLinkResponse(linkId: linkId, pendingRef: pendingRef)
+        return EnchantedLinkResponse(linkId: linkId, pendingRef: pendingRef, maskedEmail: maskedEmail)
     }
 }

--- a/src/routes/MagicLink.swift
+++ b/src/routes/MagicLink.swift
@@ -8,24 +8,24 @@ class MagicLink: DescopeMagicLink {
         self.client = client
     }
     
-    func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws {
-        try await client.magicLinkSignUp(with: method, loginId: loginId, user: user, uri: uri)
+    func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws -> String {
+        return try await client.magicLinkSignUp(with: method, loginId: loginId, user: user, uri: uri).convert(method: method)
     }
     
-    func signIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws {
-        try await client.magicLinkSignIn(with: method, loginId: loginId, uri: uri)
+    func signIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> String {
+        return try await client.magicLinkSignIn(with: method, loginId: loginId, uri: uri).convert(method: method)
     }
     
-    func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws {
-        try await client.magicLinkSignUpOrIn(with: method, loginId: loginId, uri: uri)
+    func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> String {
+        return try await client.magicLinkSignUpOrIn(with: method, loginId: loginId, uri: uri).convert(method: method)
     }
     
-    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws {
-        try await client.magicLinkUpdateEmail(email, loginId: loginId, uri: uri, refreshJwt: refreshJwt)
+    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> String {
+        return try await client.magicLinkUpdateEmail(email, loginId: loginId, uri: uri, refreshJwt: refreshJwt).convert(method: .email)
     }
     
-    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws {
-        try await client.magicLinkUpdatePhone(phone, with: method, loginId: loginId, uri: uri, refreshJwt: refreshJwt)
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws -> String {
+        return try await client.magicLinkUpdatePhone(phone, with: method, loginId: loginId, uri: uri, refreshJwt: refreshJwt).convert(method: method)
     }
     
     func verify(token: String) async throws -> DescopeSession {

--- a/src/routes/OTP.swift
+++ b/src/routes/OTP.swift
@@ -6,27 +6,27 @@ class OTP: DescopeOTP {
         self.client = client
     }
 
-    func signUp(with method: DeliveryMethod, loginId: String, user: User) async throws {
-        try await client.otpSignUp(with: method, loginId: loginId, user: user)
+    func signUp(with method: DeliveryMethod, loginId: String, user: User) async throws -> String {
+        return try await client.otpSignUp(with: method, loginId: loginId, user: user).convert(method: method)
     }
     
-    func signIn(with method: DeliveryMethod, loginId: String) async throws {
-        try await client.otpSignIn(with: method, loginId: loginId)
+    func signIn(with method: DeliveryMethod, loginId: String) async throws -> String {
+        return try await client.otpSignIn(with: method, loginId: loginId).convert(method: method)
     }
     
-    func signUpOrIn(with method: DeliveryMethod, loginId: String) async throws {
-        try await client.otpSignUpIn(with: method, loginId: loginId)
+    func signUpOrIn(with method: DeliveryMethod, loginId: String) async throws -> String {
+        return try await client.otpSignUpIn(with: method, loginId: loginId).convert(method: method)
     }
     
     func verify(with method: DeliveryMethod, loginId: String, code: String) async throws -> DescopeSession {
         return try await client.otpVerify(with: method, loginId: loginId, code: code).convert()
     }
     
-    func updateEmail(_ email: String, loginId: String, refreshJwt: String) async throws {
-        try await client.otpUpdateEmail(email, loginId: loginId, refreshJwt: refreshJwt)
+    func updateEmail(_ email: String, loginId: String, refreshJwt: String) async throws -> String {
+        return try await client.otpUpdateEmail(email, loginId: loginId, refreshJwt: refreshJwt).convert(method: .email)
     }
     
-    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws {
-        try await client.otpUpdatePhone(phone, with: method, loginId: loginId, refreshJwt: refreshJwt)
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws -> String {
+        return try await client.otpUpdatePhone(phone, with: method, loginId: loginId, refreshJwt: refreshJwt).convert(method: method)
     }
 }

--- a/src/routes/Shared.swift
+++ b/src/routes/Shared.swift
@@ -5,3 +5,16 @@ extension DescopeClient.JWTResponse {
         return try DescopeSession(sessionJwt: sessionJwt, refreshJwt: refreshJwt)
     }
 }
+
+extension DescopeClient.MaskedAddress {
+    func convert(method: DeliveryMethod) throws -> String {
+        switch method {
+        case .email:
+            guard let maskedEmail else { throw DescopeError.decodeError.with(message: "Missing masked email") }
+            return maskedEmail
+        case .sms, .whatsapp:
+            guard let maskedPhone else { throw DescopeError.decodeError.with(message: "Missing masked phone") }
+            return maskedPhone
+        }
+    }
+}

--- a/src/sdk/Callbacks.swift
+++ b/src/sdk/Callbacks.swift
@@ -262,7 +262,7 @@ public extension DescopeMagicLink {
     ///   - user: Details about the user signing up.
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+    func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signUp(with: method, loginId: loginId, user: user, uri: uri)))
@@ -284,7 +284,7 @@ public extension DescopeMagicLink {
     ///     an email, phone, or any other unique identifier.
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+    func signIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signIn(with: method, loginId: loginId, uri: uri)))
@@ -310,7 +310,7 @@ public extension DescopeMagicLink {
     ///     an email, phone, or any other unique identifier
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<Void, Error>) -> Void) {
+    func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signUpOrIn(with: method, loginId: loginId, uri: uri)))
@@ -332,7 +332,7 @@ public extension DescopeMagicLink {
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
     ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
-    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await updateEmail(email, loginId: loginId, uri: uri, refreshJwt: refreshJwt)))
@@ -358,7 +358,7 @@ public extension DescopeMagicLink {
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
     ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
-    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await updatePhone(phone, with: method, loginId: loginId, uri: uri, refreshJwt: refreshJwt)))
@@ -444,7 +444,7 @@ public extension DescopeOTP {
     ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier.
     ///   - user: Details about the user signing up.
-    func signUp(with method: DeliveryMethod, loginId: String, user: User, completion: @escaping (Result<Void, Error>) -> Void) {
+    func signUp(with method: DeliveryMethod, loginId: String, user: User, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signUp(with: method, loginId: loginId, user: user)))
@@ -461,7 +461,7 @@ public extension DescopeOTP {
     ///   - method: Deliver the OTP code using this delivery method.
     ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier.
-    func signIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func signIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signIn(with: method, loginId: loginId)))
@@ -482,7 +482,7 @@ public extension DescopeOTP {
     ///   - method: Deliver the OTP code using this delivery method.
     ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier
-    func signUpOrIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func signUpOrIn(with method: DeliveryMethod, loginId: String, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await signUpOrIn(with: method, loginId: loginId)))
@@ -520,7 +520,7 @@ public extension DescopeOTP {
     ///   - email: The email address to add.
     ///   - loginId: The existing user's loginId
     ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
-    func updateEmail(_ email: String, loginId: String, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func updateEmail(_ email: String, loginId: String, refreshJwt: String, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await updateEmail(email, loginId: loginId, refreshJwt: refreshJwt)))
@@ -543,7 +543,7 @@ public extension DescopeOTP {
     ///   - method: Deliver the OTP code using this delivery method.
     ///   - loginId: The existing user's loginId
     ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
-    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String, completion: @escaping (Result<String, Error>) -> Void) {
         Task {
             do {
                 completion(.success(try await updatePhone(phone, with: method, loginId: loginId, refreshJwt: refreshJwt)))

--- a/src/sdk/Routes.swift
+++ b/src/sdk/Routes.swift
@@ -59,7 +59,7 @@ public protocol DescopeOTP {
     ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier.
     ///   - user: Details about the user signing up.
-    func signUp(with method: DeliveryMethod, loginId: String, user: User) async throws
+    func signUp(with method: DeliveryMethod, loginId: String, user: User) async throws -> String
     
     /// Authenticates an existing user using an OTP, sent via a delivery
     /// method of choice.
@@ -68,7 +68,7 @@ public protocol DescopeOTP {
     ///   - method: Deliver the OTP code using this delivery method.
     ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier.
-    func signIn(with method: DeliveryMethod, loginId: String) async throws
+    func signIn(with method: DeliveryMethod, loginId: String) async throws -> String
     
     /// Authenticates an existing user if one exists, or creates a new user
     /// using an OTP, sent via a delivery method of choice.
@@ -81,7 +81,7 @@ public protocol DescopeOTP {
     ///   - method: Deliver the OTP code using this delivery method.
     ///   - loginId: What identifies the user when logging in,
     ///     typically an email, phone, or any other unique identifier
-    func signUpOrIn(with method: DeliveryMethod, loginId: String) async throws
+    func signUpOrIn(with method: DeliveryMethod, loginId: String) async throws -> String
     
     /// Verifies an OTP code sent to the user.
     ///
@@ -103,7 +103,7 @@ public protocol DescopeOTP {
     ///   - email: The email address to add.
     ///   - loginId: The existing user's loginId
     ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
-    func updateEmail(_ email: String, loginId: String, refreshJwt: String) async throws
+    func updateEmail(_ email: String, loginId: String, refreshJwt: String) async throws -> String
     
     /// Updates an existing user by adding a phone number.
     ///
@@ -118,7 +118,7 @@ public protocol DescopeOTP {
     ///   - method: Deliver the OTP code using this delivery method.
     ///   - loginId: The existing user's loginId
     ///   - refreshJwt: The existing user's `refreshJwt` an active `DescopeSession`.
-    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, refreshJwt: String) async throws -> String
 }
 
 
@@ -217,7 +217,7 @@ public protocol DescopeMagicLink {
     ///   - user: Details about the user signing up.
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws
+    func signUp(with method: DeliveryMethod, loginId: String, user: User, uri: String?) async throws -> String
     
     /// Authenticates an existing user using a magic link, sent via a delivery
     /// method of choice.
@@ -231,7 +231,7 @@ public protocol DescopeMagicLink {
     ///     an email, phone, or any other unique identifier.
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws
+    func signIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> String
     
     /// Authenticates an existing user if one exists, or creates a new user
     /// using a magic link, sent via a delivery method of choice.
@@ -249,7 +249,7 @@ public protocol DescopeMagicLink {
     ///     an email, phone, or any other unique identifier
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
-    func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws
+    func signUpOrIn(with method: DeliveryMethod, loginId: String, uri: String?) async throws -> String
     
     /// Updates an existing user by adding an email address.
     ///
@@ -263,7 +263,7 @@ public protocol DescopeMagicLink {
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
     ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
-    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws
+    func updateEmail(_ email: String, loginId: String, uri: String?, refreshJwt: String) async throws -> String
     
     /// Updates an existing user by adding a phone number.
     ///
@@ -281,7 +281,7 @@ public protocol DescopeMagicLink {
     ///   - uri: Optional URI that will be used to generate the magic link.
     ///     If not given, the project default will be used.
     ///   - refreshJwt: The existing user's `refreshJwt` from an active `DescopeSession`.
-    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws
+    func updatePhone(_ phone: String, with method: DeliveryMethod, loginId: String, uri: String?, refreshJwt: String) async throws -> String
     
     /// Verifies a magic link token.
     ///

--- a/src/types/Others.swift
+++ b/src/types/Others.swift
@@ -49,6 +49,7 @@ public struct MeResponse {
 public struct EnchantedLinkResponse {
     public var linkId: String
     public var pendingRef: String
+    public var maskedEmail: String
 }
 
 public struct TOTPResponse {


### PR DESCRIPTION
This applies to otp magic link and enchanted link
Use of magic link and otp will break compilation upon upgrading to this version The value is returned upon initiation of the signup/in method and returned in masked format

