### PR TITLE
Add support for custom OAuth providers

### DIFF
--- a/src/internal/http/DescopeClient.swift
+++ b/src/internal/http/DescopeClient.swift
@@ -248,7 +248,7 @@ class DescopeClient: HTTPClient {
     
     func oauthStart(provider: OAuthProvider, redirectURL: String?, refreshJwt: String?, options: LoginOptions?) async throws -> OAuthResponse {
         return try await post("auth/oauth/authorize", headers: authorization(with: refreshJwt), params: [
-            "provider": provider.rawValue,
+            "provider": provider.name,
             "redirectUrl": redirectURL
         ], body: options?.dictValue ?? [:])
     }

--- a/src/sdk/Callbacks.swift
+++ b/src/sdk/Callbacks.swift
@@ -443,11 +443,17 @@ public extension DescopeOAuth {
     /// 
     /// It's recommended to use `ASWebAuthenticationSession` to perform the authentication.
     /// 
+    ///     // use one of the built in constants for the OAuth provider
+    ///     let authURL = try await Descope.oauth.start(provider: .apple, redirectURL: nil)
+    /// 
+    ///     // or pass a string with the name of a custom provider
+    ///     let authURL = try await Descope.oauth.start(provider: "myprovider", redirectURL: nil)
+    /// 
     /// - Important: Make sure a default OAuth redirect URL is configured
     ///     in the Descope console, or provided by this call.
     /// 
     /// - Parameters:
-    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - provider: The provider the user wishes to authenticate with.
     ///   - redirectURL: An optional parameter to generate the OAuth link.
     ///     If not given, the project default will be used.
     ///   - options: Require additional behaviors when authenticating a user.
@@ -743,7 +749,7 @@ public extension DescopeSSO {
     ///     in the Descope console, or provided by this call.
     /// 
     /// - Parameters:
-    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - emailOrTenantName: The user's email address or tenant name.
     ///   - redirectURL: An optional parameter to generate the SSO link.
     ///     If not given, the project default will be used.
     ///   - options: Require additional behaviors when authenticating a user.

--- a/src/sdk/Routes.swift
+++ b/src/sdk/Routes.swift
@@ -423,11 +423,17 @@ public protocol DescopeOAuth {
     ///
     /// It's recommended to use `ASWebAuthenticationSession` to perform the authentication.
     ///
+    ///     // use one of the built in constants for the OAuth provider
+    ///     let authURL = try await Descope.oauth.start(provider: .apple, redirectURL: nil)
+    ///
+    ///     // or pass a string with the name of a custom provider
+    ///     let authURL = try await Descope.oauth.start(provider: "myprovider", redirectURL: nil)
+    ///
     /// - Important: Make sure a default OAuth redirect URL is configured
     ///     in the Descope console, or provided by this call.
     ///
     /// - Parameters:
-    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - provider: The provider the user wishes to authenticate with.
     ///   - redirectURL: An optional parameter to generate the OAuth link.
     ///     If not given, the project default will be used.
     ///   - options: Require additional behaviors when authenticating a user.
@@ -462,7 +468,7 @@ public protocol DescopeSSO {
     ///     in the Descope console, or provided by this call.
     ///
     /// - Parameters:
-    ///   - provider: The provider the user wishes to be authenticated by.
+    ///   - emailOrTenantName: The user's email address or tenant name.
     ///   - redirectURL: An optional parameter to generate the SSO link.
     ///     If not given, the project default will be used.
     ///   - options: Require additional behaviors when authenticating a user.

--- a/src/types/Others.swift
+++ b/src/types/Others.swift
@@ -12,13 +12,20 @@ public enum DeliveryMethod: String {
 }
 
 /// The provider to use in an OAuth flow.
-public enum OAuthProvider: String {
-    case facebook
-    case github
-    case google
-    case microsoft
-    case gitlab
-    case apple
+public struct OAuthProvider: ExpressibleByStringLiteral {
+    public static let facebook: OAuthProvider = "facebook"
+    public static let github: OAuthProvider = "github"
+    public static let google: OAuthProvider = "google"
+    public static let microsoft: OAuthProvider = "microsoft"
+    public static let gitlab: OAuthProvider = "gitlab"
+    public static let apple: OAuthProvider = "apple"
+    public static let slack: OAuthProvider = "slack"
+
+    public let name: String
+    
+    public init(stringLiteral value: String) {
+        name = value
+    }
 }
 
 /// Used to provide additional details about a user in sign up calls.

--- a/src/types/Others.swift
+++ b/src/types/Others.swift
@@ -20,6 +20,7 @@ public struct OAuthProvider: ExpressibleByStringLiteral {
     public static let gitlab: OAuthProvider = "gitlab"
     public static let apple: OAuthProvider = "apple"
     public static let slack: OAuthProvider = "slack"
+    public static let discord: OAuthProvider = "discord"
 
     public let name: String
     


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/4097

## Description
- Adds backwards compatible way to specify custom `OAuthProvider` values

## Must
- [X] Tests
- [X] Documentation (if applicable)

