### PR TITLE
Replace config and projectId setters with setup function

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ an authenticated user.
 
 ```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    Descope.setup(project: "...")
+    Descope.setup(projectId: "...")
     if let session = Descope.sessionManager.session {
         print("User is logged in: \(session)")
     }

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ the Descope Console.
 import DescopeKit
 
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    Descope.projectId = "<Your-Project-Id>"
+    Descope.setup(projectId: "<Your-Project-Id>")
     return true
 }
 ```
@@ -117,7 +117,7 @@ an authenticated user.
 
 ```swift
 func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    Descope.projectId = "..."
+    Descope.setup(project: "...")
     if let session = Descope.sessionManager.session {
         print("User is logged in: \(session)")
     }

--- a/src/docs/DescopeKit.docc/Documentation.md
+++ b/src/docs/DescopeKit.docc/Documentation.md
@@ -30,11 +30,12 @@ on the [Descope website](https://descope.com).
 - ``DescopeAuth``
 - ``DescopeOTP``
 - ``DescopeTOTP``
+- ``DescopePasskey``
+- ``DescopePassword``
 - ``DescopeMagicLink``
 - ``DescopeEnchantedLink``
 - ``DescopeOAuth``
 - ``DescopeSSO``
-- ``DescopePassword``
 - ``DescopeAccessKey``
 
 ### Flows
@@ -53,6 +54,7 @@ on the [Descope website](https://descope.com).
 ### Parameter Types
 
 - ``SignUpDetails``
+- ``SignInOptions``
 - ``UpdateOptions``
 - ``DeliveryMethod``
 - ``OAuthProvider``

--- a/src/internal/others/Deprecated.swift
+++ b/src/internal/others/Deprecated.swift
@@ -57,3 +57,34 @@ public extension DescopeSSO {
         return try await start(emailOrTenantName: emailOrTenantName, redirectURL: redirectURL, options: [])
     }
 }
+
+public extension DescopeSDK {
+    @available(*, deprecated, message: "Use the DescopeSDK.init(projectId:with:) initializer instead")
+    convenience init(config: DescopeConfig) {
+        self.init(projectId: config.projectId, with: { $0 = config })
+    }
+}
+
+public extension Descope {
+    static var projectId: String {
+        @available(*, deprecated, message: "Use Descope.config.projectId instead")
+        get { Descope.sdk.config.projectId }
+        @available(*, deprecated, message: "Use the setup() function to initialize the Descope singleton")
+        set { Descope.sdk = DescopeSDK(projectId: newValue) }
+    }
+
+    static var config: DescopeConfig {
+        get { Descope.sdk.config }
+        @available(*, deprecated, message: "Use the setup() function to initialize the Descope singleton")
+        set { Descope.sdk = DescopeSDK(projectId: newValue.projectId, with: { $0 = newValue }) }
+    }
+}
+
+public extension DescopeConfig {
+    @available(*, deprecated, message: "Use the Descope.setup() function or DescopeSDK.init(projectId:with:) initializer instead")
+    init(projectId: String, baseURL: String? = nil, logger: DescopeLogger? = nil) {
+        self.projectId = projectId
+        self.baseURL = baseURL
+        self.logger = logger
+    }
+}

--- a/src/internal/others/Internal.swift
+++ b/src/internal/others/Internal.swift
@@ -1,8 +1,8 @@
 
 import AuthenticationServices
 
-extension DescopeConfig {
-    static let initial: DescopeConfig = DescopeConfig(projectId: "")
+extension DescopeSDK {
+    static let initial: DescopeSDK = DescopeSDK(projectId: "")
 }
 
 extension DescopeError {

--- a/src/sdk/Callbacks.swift
+++ b/src/sdk/Callbacks.swift
@@ -668,8 +668,8 @@ public extension DescopePasskey {
     ///     typically an email, phone, or any other unique identifier.
     ///   - details: Optional details about the user signing up.
     /// 
-    /// - Throws: ``DescopeError/passkeyCancelled`` if the ``DescopePasskeyRunner/cancel()``
-    ///     method is called on the runner or the authentication view is cancelled by the user.
+    /// - Throws: ``DescopeError/passkeyCancelled`` if the async task is cancelled or
+    ///     the authentication view is cancelled by the user.
     /// 
     /// - Returns: An ``AuthenticationResponse`` value upon successful authentication.
     @available(iOS 15.0, *)
@@ -690,8 +690,8 @@ public extension DescopePasskey {
     ///     typically an email, phone, or any other unique identifier.
     ///   - options: Additional behaviors to perform during authentication.
     /// 
-    /// - Throws: ``DescopeError/passkeyCancelled`` if the ``DescopePasskeyRunner/cancel()``
-    ///     method is called on the runner or the authentication view is cancelled by the user.
+    /// - Throws: ``DescopeError/passkeyCancelled`` if the async task is cancelled or
+    ///     the authentication view is cancelled by the user.
     /// 
     /// - Returns: An ``AuthenticationResponse`` value upon successful authentication.
     @available(iOS 15.0, *)
@@ -715,8 +715,8 @@ public extension DescopePasskey {
     ///     typically an email, phone, or any other unique identifier.
     ///   - options: Additional behaviors to perform during authentication.
     /// 
-    /// - Throws: ``DescopeError/passkeyCancelled`` if the ``DescopePasskeyRunner/cancel()``
-    ///     method is called on the runner or the authentication view is cancelled by the user.
+    /// - Throws: ``DescopeError/passkeyCancelled`` if the async task is cancelled or
+    ///     the authentication view is cancelled by the user.
     /// 
     /// - Returns: An ``AuthenticationResponse`` value upon successful authentication.
     @available(iOS 15.0, *)
@@ -737,8 +737,8 @@ public extension DescopePasskey {
     ///     typically an email, phone, or any other unique identifier.
     ///   - refreshJwt: the `refreshJwt` from an active ``DescopeSession``.
     /// 
-    /// - Throws: ``DescopeError/passkeyCancelled`` if the ``DescopePasskeyRunner/cancel()``
-    ///     method is called on the runner or the authentication view is cancelled by the user.
+    /// - Throws: ``DescopeError/passkeyCancelled`` if the async task is cancelled or
+    ///     the authentication view is cancelled by the user.
     @available(iOS 15.0, *)
     func add(loginId: String, refreshJwt: String, completion: @escaping (Result<Void, Error>) -> Void) {
         Task {

--- a/src/sdk/Config.swift
+++ b/src/sdk/Config.swift
@@ -4,7 +4,7 @@ import Foundation
 /// The configuration of the Descope SDK.
 public struct DescopeConfig {
     /// The id of the Descope project.
-    public var projectId: String
+    public var projectId: String = ""
     
     /// An optional override for the base URL of the Descope server.
     public var baseURL: String?
@@ -15,7 +15,9 @@ public struct DescopeConfig {
     /// disabled. During development if you encounter any issues you can create an
     /// instance of the ``DescopeLogger`` class to enable logging.
     ///
-    ///     Descope.config = DescopeConfig(projectId: "...", logger: DescopeLogger())
+    ///     Descope.setup(projectId: "...") { config in
+    ///         config.logger = DescopeLogger()
+    ///     }
     ///
     /// If your application uses some logging framework or third party service you can forward
     /// the Descope SDK log messages to it by creating a new subclass of ``DescopeLogger`` and
@@ -31,20 +33,6 @@ public struct DescopeConfig {
     /// network requests actually taking place. In most other cases there shouldn't be
     /// any need to use it.
     public var networkClient: DescopeNetworkClient? = nil
-    
-    /// Creates a new ``DescopeConfig`` object.
-    ///
-    /// - Parameters:
-    ///   - projectId: The id of the Descope project can be found in the project page in
-    ///     the Descope console.
-    ///   - baseURL: An optional override for the base URL of the Descope server, in case it
-    ///     needs to be accessed through a CNAME record.
-    ///   - logger: An optional object to enable logging in the Descope SDK.
-    public init(projectId: String, baseURL: String? = nil, logger: DescopeLogger? = nil) {
-        self.projectId = projectId
-        self.baseURL = baseURL
-        self.logger = logger
-    }
 }
 
 /// The ``DescopeLogger`` class can be used to customize logging functionality in the Descope SDK.
@@ -128,9 +116,9 @@ open class DescopeLogger {
 /// the Descope SDK to use the same `URLSession` instance we use elsewhere we can
 /// use code such as this:
 ///
-///     var config = DescopeConfig(projectId: "...")
-///     config.networkClient = AppNetworkClient(session: appSession)
-///     let descopeSDK = DescopeSDK(config: config)
+///     let descopeSDK = DescopeSDK(projectId: "...") { config in
+///         config.networkClient = AppNetworkClient(session: appSession)
+///     }
 ///
 ///     // ... elsewhere
 ///

--- a/src/sdk/SDK.swift
+++ b/src/sdk/SDK.swift
@@ -77,9 +77,9 @@ public class DescopeSDK {
     ///     showAuthScreen(with: viewModel)
     ///
     /// You can also pass a closure to this initializer to perform additional configuration.
-    /// For example, if we want to test failure conditions in code that uses the Descope,
-    /// we can override the ``DescopeSDK`` object's default networking client with one
-    /// that always fails using code such as this (see ``DescopeNetworkClient``):
+    /// For example, if we want to test failure conditions in code that uses Descope, we might
+    /// override the ``DescopeSDK`` object's default networking client with one that always
+    /// fails, using code such as this (see ``DescopeNetworkClient``):
     ///
     ///     let descope = DescopeSDK(projectId: "") { config in
     ///         config.networkClient = FailingNetworkClient()

--- a/src/session/Manager.swift
+++ b/src/session/Manager.swift
@@ -38,7 +38,7 @@ import Foundation
 /// an authenticated user.
 ///
 ///     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-///         Descope.setup(project: "...")
+///         Descope.setup(projectId: "...")
 ///         if let session = Descope.sessionManager.session {
 ///             print("User is logged in: \(session)")
 ///         }

--- a/src/session/Manager.swift
+++ b/src/session/Manager.swift
@@ -38,7 +38,7 @@ import Foundation
 /// an authenticated user.
 ///
 ///     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-///         Descope.projectId = "..."
+///         Descope.setup(project: "...")
 ///         if let session = Descope.sessionManager.session {
 ///             print("User is logged in: \(session)")
 ///         }

--- a/src/types/Flows.swift
+++ b/src/types/Flows.swift
@@ -38,7 +38,7 @@ public class DescopeFlowRunner {
         /// The refresh JWT from and active descope session
         public var refreshJwt: String
         
-        /// Creates a new ``DescopeFlowRunner.Authentication`` object that encapsulates the
+        /// Creates a new ``DescopeFlowRunner/Authentication`` object that encapsulates the
         /// information required to run a flow for an authenticated user.
         ///
         /// - Parameter flowId: The flow ID about to be run.

--- a/src/types/Others.swift
+++ b/src/types/Others.swift
@@ -103,7 +103,7 @@ public struct UpdateOptions: OptionSet {
     
     /// Whether to keep or delete the current user when merging two users after an update.
     ///
-    /// When updating a user's email address or phone number with the ``addToUserLoginIds``
+    /// When updating a user's email address or phone number with the ``addToLoginIds``
     /// option set, if another user in the the system already has the same email address
     /// or phone number as the one being added in their list of `loginIds` the two users
     /// are merged and one of them is deleted.

--- a/test/mocks/MockDescope.swift
+++ b/test/mocks/MockDescope.swift
@@ -3,8 +3,9 @@ import Foundation
 
 extension DescopeSDK {
     static func mock(projectId: String = "projId") -> DescopeSDK {
-        var config = DescopeConfig(projectId: projectId, logger: DescopeLogger())
-        config.networkClient = MockHTTP.networkClient
-        return DescopeSDK(config: config)
+        return DescopeSDK(projectId: projectId) { config in
+            config.logger = DescopeLogger()
+            config.networkClient = MockHTTP.networkClient
+        }
     }
 }


### PR DESCRIPTION
## Related PRs
https://github.com/descope/descope-kotlin/pull/82

## Description
- Add `Descope.setup()` function and new `DescopeSDK` initializer
- Mark `Descope` settings and previous `DescopeSDK` initializers as `deprecated`

## Must
- [X] Tests
- [X] Documentation (if applicable)

