### PR TITLE
Token and session updates

### DIFF
--- a/src/session/Lifecycle.swift
+++ b/src/session/Lifecycle.swift
@@ -48,8 +48,7 @@ public class SessionLifecycle: DescopeSessionLifecycle {
     // Internal
     
     private func shouldRefresh(_ session: DescopeSession) -> Bool {
-        guard let expiresAt = session.sessionToken.expiresAt else { return false }
-        return expiresAt.timeIntervalSinceNow <= stalenessAllowedInterval
+        return session.sessionToken.expiresAt.timeIntervalSinceNow <= stalenessAllowedInterval
     }
     
     // Timer

--- a/src/session/Session.swift
+++ b/src/session/Session.swift
@@ -124,11 +124,7 @@ extension DescopeSession: CustomStringConvertible {
     /// It returns a string with the unique id of the session user as well as
     /// the refresh token's expiry time.
     public var description: String {
-        var expires = "expires: Never"
-        if let refreshExpiresAt = refreshToken.expiresAt {
-            let label = refreshToken.isExpired ? "expired" : "expires"
-            expires = "\(label): \(refreshExpiresAt)"
-        }
-        return "DescopeSession(userId: \"\(user.userId)\", \(expires))"
+        let expires = refreshToken.isExpired ? "expired" : "expires"
+        return "DescopeSession(userId: \"\(user.userId)\", \(expires): \(refreshToken.expiresAt))"
     }
 }

--- a/src/session/Token.swift
+++ b/src/session/Token.swift
@@ -12,8 +12,8 @@ public protocol DescopeToken {
     
     /// The value of the "sub" (subject) claim, which is the unique id
     /// of the user or access key the JWT was generated for.
-    var id: String { get }
-    
+    var entityId: String { get }
+
     /// The value of the "iss" (issuer) claim which is the unique id
     /// of the Descope project the JWT was generated for.
     var projectId: String { get }
@@ -26,7 +26,7 @@ public protocol DescopeToken {
     /// after which the JWT expires.
     var expiresAt: Date { get }
     
-    /// Whether the JWT expiry time (if any) has already passed.
+    /// Whether the JWT expiry time  has already passed.
     var isExpired: Bool { get }
     
     /// A map with all the custom claims in the JWT value. It includes
@@ -49,7 +49,7 @@ public protocol DescopeToken {
 
 class Token: DescopeToken {
     let jwt: String
-    let id: String
+    let entityId: String
     let projectId: String
     let issuedAt: Date
     let expiresAt: Date
@@ -60,7 +60,7 @@ class Token: DescopeToken {
         do {
             let dict = try decodeJWT(jwt)
             self.jwt = jwt
-            self.id = try getClaim(.subject, in: dict)
+            self.entityId = try getClaim(.subject, in: dict)
             self.projectId = try decodeIssuer(getClaim(.issuer, in: dict))
             self.issuedAt = try Date(timeIntervalSince1970: getClaim(.issuedAt, in: dict))
             self.expiresAt = try Date(timeIntervalSince1970: getClaim(.expiration, in: dict))
@@ -113,7 +113,7 @@ class Token: DescopeToken {
 extension Token: CustomStringConvertible {
     var description: String {
         let expires = isExpired ? "expired" : "expires"
-        return "DescopeToken(id: \"\(id)\", \(expires): \(expiresAt))"
+        return "DescopeToken(entityId: \"\(entityId)\", \(expires): \(expiresAt))"
     }
 }
 

--- a/test/routes/AccessKey.swift
+++ b/test/routes/AccessKey.swift
@@ -16,7 +16,7 @@ class TestAccessKey: XCTestCase {
         
         let token = try await descope.accessKey.exchange(accessKey: "key")
         XCTAssertEqual(jwt, token.jwt)
-        XCTAssertEqual("bar", token.id)
+        XCTAssertEqual("bar", token.entityId)
         XCTAssertEqual("foo", token.projectId)
         XCTAssertTrue(token.isExpired)
     }

--- a/test/session/Token.swift
+++ b/test/session/Token.swift
@@ -25,7 +25,7 @@ class TestToken: XCTestCase {
         XCTAssertNotNil(token.expiresAt)
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "dd.MM.yyyy"
-        XCTAssertEqual("20.10.2020", dateFormatter.string(from: token.expiresAt!))
+        XCTAssertEqual("20.10.2020", dateFormatter.string(from: token.expiresAt))
         XCTAssertTrue(token.isExpired)
 
         // Custom Claims

--- a/test/session/Token.swift
+++ b/test/session/Token.swift
@@ -18,11 +18,10 @@ class TestToken: XCTestCase {
         
         // Basic Fields
         XCTAssertEqual(jwt, token.jwt)
-        XCTAssertEqual("1234567890", token.id)
+        XCTAssertEqual("1234567890", token.entityId)
         XCTAssertEqual("P123", token.projectId)
         
         // Expiration
-        XCTAssertNotNil(token.expiresAt)
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "dd.MM.yyyy"
         XCTAssertEqual("20.10.2020", dateFormatter.string(from: token.expiresAt))


### PR DESCRIPTION
## Description
- Make `expiresAt` field non-optional
- Add `issuedAt` accessor
- Don't filter `aud` claim from `claims` accessor as we don't currently expose it otherwise
- Change `id` property in `DescopeToken` to `entityId`

## Must
- [X] Tests
- [X] Documentation (if applicable)

