### PR TITLE
Fixes UserResponse to properly parse custom attributes

### DIFF
--- a/src/internal/http/DescopeClient.swift
+++ b/src/internal/http/DescopeClient.swift
@@ -421,6 +421,7 @@ class DescopeClient: HTTPClient {
                     refreshJwt = cookie.value
                 }
             }
+            try user?.setValues(from: data, response: response)
         }
     }
     
@@ -450,7 +451,14 @@ class DescopeClient: HTTPClient {
 
         mutating func setValues(from data: Data, response: HTTPURLResponse) throws {
             let json = try JSONSerialization.jsonObject(with: data) as? [String: Any] ?? [:]
-            customAttributes = json["customAttributes"] as? [String: Any] ?? [:]
+            let user = json["user"] as? [String: Any] ?? [:]
+            if let customAttributes = json["customAttributes"] as? [String: Any] {
+                self.customAttributes = customAttributes
+            } else if let userCustomAttributes = user["customAttributes"] as? [String: Any] {
+                self.customAttributes = userCustomAttributes
+            } else {
+                self.customAttributes = [:]
+            }
         }
     }
     


### PR DESCRIPTION
## Related Issues
Fixes [UserResponse doesn't parse customAttributes](https://github.com/descope/swift-sdk/issues/64)

## Related PRs
branch | PR
------ | ------
service a PR | Link to PR
service b PR | Link to PR

## Description
Currently the `UserResponse` object does not parse the `customAttributes` data passed to it by the json decoder. As a result, neither it, nor the `DescopeUser` object contain customAttributes. This fixes that problem.

## Must
- [ ] Tests
- [ ] Documentation (if applicable)

