### PR TITLE
Bump version to 0.9.5

### DIFF
--- a/src/sdk/SDK.swift
+++ b/src/sdk/SDK.swift
@@ -125,7 +125,7 @@ public extension DescopeSDK {
     static let name = "DescopeKit"
     
     /// The Descope SDK version
-    static let version = "0.9.4"
+    static let version = "0.9.5"
 }
 
 // Internal

--- a/test/routes/Auth.swift
+++ b/test/routes/Auth.swift
@@ -5,12 +5,34 @@ class TestAuth: XCTestCase {
     func testMe() async throws {
         let descope = DescopeSDK.mock()
 
-        MockHTTP.push(body: mePayload) { request in
+        MockHTTP.push(body: userPayload) { request in
             XCTAssertEqual(request.httpMethod, "GET")
             XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer projId:jwt")
         }
 
         let user = try await descope.auth.me(refreshJwt: "jwt")
+
+        try checkUser(user)
+    }
+
+    func testAuth() async throws {
+        let descope = DescopeSDK.mock()
+
+        MockHTTP.push(body: authPayload) { request in
+            XCTAssertEqual(request.httpMethod, "POST")
+            XCTAssertEqual(request.url?.absoluteString ?? "", "https://api.descope.com/v1/auth/otp/verify/email")
+            XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], "Bearer projId")
+        }
+
+        let authResponse = try await descope.otp.verify(with: .email, loginId: "foo", code: "123456")
+        XCTAssertEqual("bar", authResponse.sessionToken.entityId)
+        XCTAssertEqual("qux", authResponse.refreshToken.entityId)
+        XCTAssertTrue(authResponse.isFirstAuthentication)
+
+        try checkUser(authResponse.user)
+    }
+
+    func checkUser(_ user: DescopeUser) throws {
         XCTAssertEqual("userId", user.userId)
         XCTAssertFalse(user.isVerifiedPhone)
         XCTAssertTrue(user.isVerifiedEmail)
@@ -41,7 +63,16 @@ class TestAuth: XCTestCase {
     }
 }
 
-private let mePayload = """
+private let authPayload = """
+{
+    "sessionJwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiYXIiLCJuYW1lIjoiU3dpZnR5IE1jQXBwbGVzIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJmb28iLCJleHAiOjE2MDMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0.LEcNdzkdOXlzxcVNhvlqOIoNwzgYYfcDv1_vzF3awF8",
+    "refreshJwt": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJxdXgiLCJuYW1lIjoiU3dpZnR5IE1jQXBwbGVzIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJmb28iLCJleHAiOjE2MDMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0.kgsfovgtFXwlr7Ev6XZ_BFMBSFNgTraw_G9WqAj78AA",
+    "user": \(userPayload),
+    "firstSeen": true
+}
+"""
+
+private let userPayload = """
 {
     "userId": "userId",
     "loginIds": ["loginId"],


### PR DESCRIPTION
## Description
- Bump version to `0.9.5`.
- Update custom attribute handling to be more explicit in where we expect the values to be in the response body.
- Add unit test for custom attributes in both me and auth responses.

## Must
- [X] Tests
- [X] Documentation (if applicable)

