### PR TITLE
Refactor DescopeSession to be a Sendable struct

### DIFF
--- a/src/session/Lifecycle.swift
+++ b/src/session/Lifecycle.swift
@@ -45,21 +45,22 @@ public class SessionLifecycle: DescopeSessionLifecycle {
         session?.updateTokens(with: response)
     }
     
-    // Internal
+    // Conditional refresh
     
     private func shouldRefresh(_ session: DescopeSession) -> Bool {
         return session.sessionToken.expiresAt.timeIntervalSinceNow <= stalenessAllowedInterval
     }
     
-    // Timer
-    
+    // Periodic refresh
+
     private var timer: Timer?
     
     private func startTimer() {
         timer?.invalidate()
-        timer = Timer.scheduledTimer(withTimeInterval: stalenessCheckFrequency, repeats: true) { [weak self] _ in
+        timer = Timer.scheduledTimer(withTimeInterval: stalenessCheckFrequency, repeats: true) { [weak self] timer in
+            guard let lifecycle = self else { return timer.invalidate() }
             Task { @MainActor in
-                await self?.periodicRefresh()
+                await lifecycle.periodicRefresh()
             }
         }
     }

--- a/src/session/Lifecycle.swift
+++ b/src/session/Lifecycle.swift
@@ -33,8 +33,8 @@ public class SessionLifecycle: DescopeSessionLifecycle {
         didSet {
             if session == nil {
                 stopTimer()
-            } else {
-                startTimer()
+            } else if session?.refreshJwt != oldValue?.refreshJwt {
+                restartTimer()
             }
         }
     }
@@ -55,7 +55,7 @@ public class SessionLifecycle: DescopeSessionLifecycle {
 
     private var timer: Timer?
     
-    private func startTimer() {
+    private func restartTimer() {
         timer?.invalidate()
         timer = Timer.scheduledTimer(withTimeInterval: stalenessCheckFrequency, repeats: true) { [weak self] timer in
             guard let lifecycle = self else { return timer.invalidate() }

--- a/src/session/Session.swift
+++ b/src/session/Session.swift
@@ -26,7 +26,7 @@ import Foundation
 /// it's recommended to let a ``DescopeSessionManager`` object manage it instead,
 /// and the code examples above are only slightly different. See the documentation
 /// for ``DescopeSessionManager`` for more details.
-public class DescopeSession: @unchecked Sendable {
+public struct DescopeSession: Sendable {
     /// The wrapper for the short lived JWT that can be sent with every server
     /// request that requires authentication.
     public private(set) var sessionToken: DescopeToken
@@ -42,7 +42,7 @@ public class DescopeSession: @unchecked Sendable {
     ///
     /// Use this initializer to create a ``DescopeSession`` after the user completes
     /// a sign in or sign up flow in the application.
-    public convenience init(from response: AuthenticationResponse) {
+    public init(from response: AuthenticationResponse) {
         self.init(sessionToken: response.sessionToken, refreshToken: response.refreshToken, user: response.user)
     }
     
@@ -50,7 +50,7 @@ public class DescopeSession: @unchecked Sendable {
     ///
     /// This initializer can be used to manually recreate a user's ``DescopeSession`` after
     /// the application is relaunched if not using a ``DescopeSessionManager`` for this.
-    public convenience init(sessionJwt: String, refreshJwt: String, user: DescopeUser) throws {
+    public init(sessionJwt: String, refreshJwt: String, user: DescopeUser) throws {
         let sessionToken = try Token(jwt: sessionJwt)
         let refreshToken = try Token(jwt: refreshJwt)
         self.init(sessionToken: sessionToken, refreshToken: refreshToken, user: user)
@@ -100,7 +100,7 @@ public extension DescopeSession {
     /// - Important: It's recommended to use a ``DescopeSessionManager`` to manage sessions,
     ///     in which case you should call `updateTokens` on the manager itself, or
     ///     just call `refreshSessionIfNeeded` on the manager to do everything for you.
-    func updateTokens(with refreshResponse: RefreshResponse) {
+    mutating func updateTokens(with refreshResponse: RefreshResponse) {
         sessionToken = refreshResponse.sessionToken
         refreshToken = refreshResponse.refreshToken ?? refreshToken
     }
@@ -113,7 +113,7 @@ public extension DescopeSession {
     /// - Important: It's recommended to use a ``DescopeSessionManager`` to manage sessions,
     ///     in which case you should call `updateUser` on the manager itself instead
     ///     to ensure that the updated user details are saved.
-    func updateUser(with user: DescopeUser) {
+    mutating func updateUser(with user: DescopeUser) {
         self.user = user
     }
 }


### PR DESCRIPTION
## Related PRs
https://github.com/descope/swift-sdk/pull/66

## Description
- Refactor `DescopeSession` to be a `Sendable` struct
- Ensure session lifecycle timer is eventually invalidated
- Restart session lifecycle timer only if refresh token changed
- Allow disabling periodic refresh

## Must
- [X] Tests
- [X] Documentation (if applicable)

