### PR TITLE
Revoke sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ active session and clear it from the session manager:
 
 ```swift
 guard let refreshJwt = Descope.sessionManager.session?.refreshJwt else { return }
-try await Descope.auth.logout(refreshJwt: refreshJwt)
+try await Descope.auth.revokeSessions(.currentSession, refreshJwt: refreshJwt)
 Descope.sessionManager.clearSession()
 ```
 
@@ -360,7 +360,7 @@ you configured in the Descope console earlier.
 ```swift
 do {
     showLoading(true)
-    let authResponse = try await Descope.passkey.native(provider: .apple, options: [])
+    let authResponse = try await Descope.passkey.signUpOrIn(loginId: "andy@example.com", options: [])
     let session = DescopeSession(from: authResponse)
     Descope.sessionManager.manageSession(session)
     showHomeScreen() 

--- a/src/internal/http/DescopeClient.swift
+++ b/src/internal/http/DescopeClient.swift
@@ -399,8 +399,6 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         switch type {
         case .currentSession:
             try await post("auth/logout", headers: authorization(with: refreshJwt))
-        case .otherSessions:
-            try await post("auth/logoutprevious", headers: authorization(with: refreshJwt))
         case .allSessions:
             try await post("auth/logoutall", headers: authorization(with: refreshJwt))
         }
@@ -485,12 +483,14 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         var stepup: Bool = false
         var mfa: Bool = false
         var customClaims: [String: Any] = [:]
+        var revokeOtherSessions = false
 
         var dictValue: [String: Any?] {
             return [
                 "stepup": stepup ? true : nil,
                 "mfa": mfa ? true : nil,
                 "customClaims": customClaims.isEmpty ? nil : customClaims,
+                "revokeOtherSessions": revokeOtherSessions ? true : nil,
             ]
         }
     }

--- a/src/internal/http/DescopeClient.swift
+++ b/src/internal/http/DescopeClient.swift
@@ -395,8 +395,15 @@ final class DescopeClient: HTTPClient, @unchecked Sendable {
         return try await post("auth/refresh", headers: authorization(with: refreshJwt))
     }
     
-    func logout(refreshJwt: String) async throws {
-        try await post("auth/logout", headers: authorization(with: refreshJwt))
+    func logout(type: RevokeType, refreshJwt: String) async throws {
+        switch type {
+        case .currentSession:
+            try await post("auth/logout", headers: authorization(with: refreshJwt))
+        case .otherSessions:
+            try await post("auth/logoutprevious", headers: authorization(with: refreshJwt))
+        case .allSessions:
+            try await post("auth/logoutall", headers: authorization(with: refreshJwt))
+        }
     }
     
     // MARK: - Shared

--- a/src/internal/others/Deprecated.swift
+++ b/src/internal/others/Deprecated.swift
@@ -68,6 +68,13 @@ public extension DescopeSSO {
     }
 }
 
+public extension DescopeAuth {
+    @available(*, deprecated, message: "Call revokeSessions(.currentSession, refreshJwt: refreshJwt) instead")
+    func logout(refreshJwt: String) async throws {
+        return try await revokeSessions(.currentSession, refreshJwt: refreshJwt)
+    }
+}
+
 public extension DescopeSDK {
     @available(*, deprecated, message: "Use the DescopeSDK.init(projectId:with:) initializer instead")
     convenience init(config: DescopeConfig) {

--- a/src/internal/routes/Auth.swift
+++ b/src/internal/routes/Auth.swift
@@ -14,7 +14,7 @@ final class Auth: DescopeAuth {
         return try await client.refresh(refreshJwt: refreshJwt).convert()
     }
 
-    func logout(refreshJwt: String) async throws {
-        try await client.logout(refreshJwt: refreshJwt)
+    func revokeSessions(_ revoke: RevokeType, refreshJwt: String) async throws {
+        try await client.logout(type: revoke, refreshJwt: refreshJwt)
     }
 }

--- a/src/internal/routes/Shared.swift
+++ b/src/internal/routes/Shared.swift
@@ -97,6 +97,8 @@ extension [SignInOptions] {
             case .mfa(let value):
                 loginOptions.mfa = true
                 refreshJwt = value
+            case .revokeOtherSessions:
+                loginOptions.revokeOtherSessions = true
             }
         }
         return (refreshJwt, loginOptions)

--- a/src/sdk/Callbacks.swift
+++ b/src/sdk/Callbacks.swift
@@ -67,13 +67,56 @@ public extension DescopeAuth {
         }
     }
 
-    /// Logs out from an active ``DescopeSession``.
+    /// Revokes active sessions for the user.
     /// 
-    /// - Parameter refreshJwt: the `refreshJwt` from an active ``DescopeSession``.
-    func logout(refreshJwt: String, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
+    /// It's a good security practice to remove refresh JWTs from the Descope servers if
+    /// they become redundant. For example, we'll usually call this function with `.currentSession`
+    /// when the user wants to sign out of the application.
+    /// 
+    /// ```swift
+    /// func didPressSignOut() {
+    ///     guard let session = Descope.sessionManager.session else { return }
+    /// 
+    ///     // clear the session locally from the app and spawn a background task to revoke
+    ///     // the refreshJWT from the Descope servers without waiting for the call to finish
+    ///     Descope.sessionManager.clearSession()
+    ///     Task {
+    ///         try? await Descope.auth.revokeSessions(.currentSession, refreshJwt: session.refreshJwt)
+    ///     }
+    /// 
+    ///     showLaunchScreen()
+    /// }
+    /// ```
+    /// 
+    /// You can also use other values of ``RevokeType`` to revoke other sessions for the
+    /// signed in user. For example, if you'd like to ensure that the user only ever has
+    /// one active session at any time:
+    /// 
+    /// ```swift
+    /// func signIn(email: String, password: String) async throws {
+    ///     // try to sign in with password for the user
+    ///     let authResponse = try await Descope.password.signIn(loginId: email, password: password)
+    ///     let session = DescopeSession(from: authResponse)
+    /// 
+    ///     // sign in succeeded so we want to sign the user out from everywhere else
+    ///     try await Descope.auth.revokeSessions(.otherSessions, refreshJwt: session.refreshJwt)
+    /// 
+    ///     // save the active session in the session manager
+    ///     Descope.sessionManager.manageSession(session)
+    /// 
+    ///     // we're now fully signed in
+    ///     showHomeScreen()
+    /// }
+    /// ```
+    /// 
+    /// - Parameters:
+    ///   - revoke: Pass `.currentSession` to revoke the session in the `refreshJwt`
+    ///     parameter or see ``RevokeType`` for more options.
+    ///   - refreshJwt: The `refreshJwt` from an active ``DescopeSession``.
+    func revokeSessions(_ revoke: RevokeType, refreshJwt: String, completion: @escaping @Sendable (Result<Void, Error>) -> Void) {
         Task {
             do {
-                completion(.success(try await logout(refreshJwt: refreshJwt)))
+                completion(.success(try await revokeSessions(revoke, refreshJwt: refreshJwt)))
             } catch {
                 completion(.failure(error))
             }

--- a/src/sdk/Callbacks.swift
+++ b/src/sdk/Callbacks.swift
@@ -70,8 +70,8 @@ public extension DescopeAuth {
     /// Revokes active sessions for the user.
     /// 
     /// It's a good security practice to remove refresh JWTs from the Descope servers if
-    /// they become redundant. For example, we'll usually call this function with `.currentSession`
-    /// when the user wants to sign out of the application.
+    /// they become redundant before expiry. This function will usually be called with `.currentSession`
+    /// when the user wants to sign out of the application. For example:
     /// 
     /// ```swift
     /// func didPressSignOut() {
@@ -88,26 +88,8 @@ public extension DescopeAuth {
     /// }
     /// ```
     /// 
-    /// You can also use other values of ``RevokeType`` to revoke other sessions for the
-    /// signed in user. For example, if you'd like to ensure that the user only ever has
-    /// one active session at any time:
-    /// 
-    /// ```swift
-    /// func signIn(email: String, password: String) async throws {
-    ///     // try to sign in with password for the user
-    ///     let authResponse = try await Descope.password.signIn(loginId: email, password: password)
-    ///     let session = DescopeSession(from: authResponse)
-    /// 
-    ///     // sign in succeeded so we want to sign the user out from everywhere else
-    ///     try await Descope.auth.revokeSessions(.otherSessions, refreshJwt: session.refreshJwt)
-    /// 
-    ///     // save the active session in the session manager
-    ///     Descope.sessionManager.manageSession(session)
-    /// 
-    ///     // we're now fully signed in
-    ///     showHomeScreen()
-    /// }
-    /// ```
+    /// - Important: When called with `.allSessions` the provided refresh JWT will not
+    ///     be usable anymore and the user will need to sign in again.
     /// 
     /// - Parameters:
     ///   - revoke: Pass `.currentSession` to revoke the session in the `refreshJwt`

--- a/src/sdk/Routes.swift
+++ b/src/sdk/Routes.swift
@@ -26,10 +26,53 @@ public protocol DescopeAuth: Sendable {
     /// - Returns: A new ``RefreshResponse`` with a refreshed `sessionJwt`.
     func refreshSession(refreshJwt: String) async throws -> RefreshResponse
     
-    /// Logs out from an active ``DescopeSession``.
+    /// Revokes active sessions for the user.
     ///
-    /// - Parameter refreshJwt: the `refreshJwt` from an active ``DescopeSession``.
-    func logout(refreshJwt: String) async throws
+    /// It's a good security practice to remove refresh JWTs from the Descope servers if
+    /// they become redundant. For example, we'll usually call this function with `.currentSession`
+    /// when the user wants to sign out of the application.
+    ///
+    /// ```swift
+    /// func didPressSignOut() {
+    ///     guard let session = Descope.sessionManager.session else { return }
+    ///
+    ///     // clear the session locally from the app and spawn a background task to revoke
+    ///     // the refreshJWT from the Descope servers without waiting for the call to finish
+    ///     Descope.sessionManager.clearSession()
+    ///     Task {
+    ///         try? await Descope.auth.revokeSessions(.currentSession, refreshJwt: session.refreshJwt)
+    ///     }
+    ///
+    ///     showLaunchScreen()
+    /// }
+    /// ```
+    ///
+    /// You can also use other values of ``RevokeType`` to revoke other sessions for the
+    /// signed in user. For example, if you'd like to ensure that the user only ever has
+    /// one active session at any time:
+    ///
+    /// ```swift
+    /// func signIn(email: String, password: String) async throws {
+    ///     // try to sign in with password for the user
+    ///     let authResponse = try await Descope.password.signIn(loginId: email, password: password)
+    ///     let session = DescopeSession(from: authResponse)
+    ///
+    ///     // sign in succeeded so we want to sign the user out from everywhere else
+    ///     try await Descope.auth.revokeSessions(.otherSessions, refreshJwt: session.refreshJwt)
+    ///
+    ///     // save the active session in the session manager
+    ///     Descope.sessionManager.manageSession(session)
+    ///
+    ///     // we're now fully signed in
+    ///     showHomeScreen()
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - revoke: Pass `.currentSession` to revoke the session in the `refreshJwt`
+    ///     parameter or see ``RevokeType`` for more options.
+    ///   - refreshJwt: The `refreshJwt` from an active ``DescopeSession``.
+    func revokeSessions(_ revoke: RevokeType, refreshJwt: String) async throws
 }
 
 

--- a/src/sdk/Routes.swift
+++ b/src/sdk/Routes.swift
@@ -29,8 +29,8 @@ public protocol DescopeAuth: Sendable {
     /// Revokes active sessions for the user.
     ///
     /// It's a good security practice to remove refresh JWTs from the Descope servers if
-    /// they become redundant. For example, we'll usually call this function with `.currentSession`
-    /// when the user wants to sign out of the application.
+    /// they become redundant before expiry. This function will usually be called with `.currentSession`
+    /// when the user wants to sign out of the application. For example:
     ///
     /// ```swift
     /// func didPressSignOut() {
@@ -47,26 +47,8 @@ public protocol DescopeAuth: Sendable {
     /// }
     /// ```
     ///
-    /// You can also use other values of ``RevokeType`` to revoke other sessions for the
-    /// signed in user. For example, if you'd like to ensure that the user only ever has
-    /// one active session at any time:
-    ///
-    /// ```swift
-    /// func signIn(email: String, password: String) async throws {
-    ///     // try to sign in with password for the user
-    ///     let authResponse = try await Descope.password.signIn(loginId: email, password: password)
-    ///     let session = DescopeSession(from: authResponse)
-    ///
-    ///     // sign in succeeded so we want to sign the user out from everywhere else
-    ///     try await Descope.auth.revokeSessions(.otherSessions, refreshJwt: session.refreshJwt)
-    ///
-    ///     // save the active session in the session manager
-    ///     Descope.sessionManager.manageSession(session)
-    ///
-    ///     // we're now fully signed in
-    ///     showHomeScreen()
-    /// }
-    /// ```
+    /// - Important: When called with `.allSessions` the provided refresh JWT will not
+    ///     be usable anymore and the user will need to sign in again.
     ///
     /// - Parameters:
     ///   - revoke: Pass `.currentSession` to revoke the session in the `refreshJwt`

--- a/src/session/Manager.swift
+++ b/src/session/Manager.swift
@@ -49,7 +49,7 @@ import Foundation
 /// session and clear it from the session manager:
 ///
 ///     guard let refreshJwt = Descope.sessionManager.session?.refreshJwt else { return }
-///     try await Descope.auth.logout(refreshJwt: refreshJwt)
+///     try await Descope.auth.revokeSessions(.currentSession, refreshJwt: refreshJwt)
 ///     Descope.sessionManager.clearSession()
 ///
 /// You can customize how the ``DescopeSessionManager`` behaves by using your own

--- a/src/types/Others.swift
+++ b/src/types/Others.swift
@@ -16,14 +16,7 @@ public enum RevokeType: Sendable {
     /// Revoke the session for the provided refresh JWT.
     case currentSession
 
-    /// Revoke all other sessions for the user, not including the session for the provided refresh JWT.
-    ///
-    /// - Important: The provided refresh JWT will still be usable afterwards.
-    case otherSessions
-
     /// Revoke all sessions for the user, including the session for the provided refresh JWT.
-    ///
-    /// - Important: The provided refresh JWT will not be usable anymore.
     case allSessions
 }
 
@@ -106,6 +99,12 @@ public enum SignInOptions: @unchecked Sendable {
     /// After the MFA authentication completes successfully the `amr` claim in both the session
     /// and refresh JWTs will be an array with an entry for each authentication method used.
     case mfa(refreshJwt: String)
+
+    /// Revoke all other active sessions for the user.
+    ///
+    /// Use this option to ensure the user only ever has one active sign in at a time, and that
+    /// refresh JWTs from previous sign ins or in other devices are revoked.
+    case revokeOtherSessions
 }
 
 /// Used to configure how users are updated.

--- a/src/types/Others.swift
+++ b/src/types/Others.swift
@@ -11,6 +11,22 @@ public enum DeliveryMethod: String, Sendable {
     case email
 }
 
+/// Which sessions are revoked when calling ``DescopeAuth/revokeSessions(_:refreshJwt:)``.
+public enum RevokeType: Sendable {
+    /// Revoke the session for the provided refresh JWT.
+    case currentSession
+
+    /// Revoke all other sessions for the user, not including the session for the provided refresh JWT.
+    ///
+    /// - Important: The provided refresh JWT will still be usable afterwards.
+    case otherSessions
+
+    /// Revoke all sessions for the user, including the session for the provided refresh JWT.
+    ///
+    /// - Important: The provided refresh JWT will not be usable anymore.
+    case allSessions
+}
+
 /// The provider to use in an OAuth flow.
 public struct OAuthProvider: Sendable, ExpressibleByStringLiteral {
     public static let facebook: OAuthProvider = "facebook"


### PR DESCRIPTION
## Related Issues
https://github.com/descope/etc/issues/8242

## Description
- Renamed `Descope.auth.logout` to `Descope.auth.revokeSessions` with a parameter that specifies whether to revoke only the provided refresh JWT (`.currentSession`) or all active sessions (`.allSessions`) for that user.
- Added `revokeOtherSessions` sign in option which revokes all other actives sessions for the user during sign in.

## Must
- [X] Tests
- [X] Documentation (if applicable)

