### PR TITLE
Flow and cookie updates

### DIFF
--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -51,6 +51,10 @@ class FlowBridge: NSObject {
     func prepare(configuration: WKWebViewConfiguration) {
         let setup = WKUserScript(source: setupScript, injectionTime: .atDocumentStart, forMainFrameOnly: false)
         configuration.userContentController.addUserScript(setup)
+
+        let zoom = WKUserScript(source: zoomScript, injectionTime: .atDocumentEnd, forMainFrameOnly: false)
+        configuration.userContentController.addUserScript(zoom)
+
         if #available(iOS 17.0, *) {
             configuration.preferences.inactiveSchedulingPolicy = .none
         }
@@ -365,6 +369,20 @@ function \(namespace)_send(type, payload) {
 
 // Performs required initializations on the page and waits for the web-component to be available
 \(namespace)_initialize()
+
+"""
+
+/// Disables two finger and double tap zooming
+private let zoomScript = """
+
+function \(namespace)_zoom() {
+    const viewport = document.createElement('meta')
+    viewport.name = 'viewport'
+    viewport.content = 'width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no'
+    document.head.appendChild(viewport)
+}
+
+\(namespace)_zoom()
 
 """
 

--- a/src/flows/FlowBridge.swift
+++ b/src/flows/FlowBridge.swift
@@ -297,7 +297,7 @@ function \(namespace)_initialize() {
 
 // Finds the Descope web-component in the webpage
 function \(namespace)_find() {
-    return document.getElementsByTagName('descope-wc')[0]
+    return document.querySelector('descope-wc')
 }
 
 // Attaches event listeners once the Descope web-component is found
@@ -320,7 +320,9 @@ function \(namespace)_prepare(component) {
         ssoRedirect: '\(WebAuth.redirectURL)',
     }
 
-    if (document.querySelector('descope-wc')?.shadowRoot?.querySelector('descope-container')) {
+    if (component.flowStatus === 'error') {
+        window.webkit.messageHandlers.\(FlowBridgeMessage.failure.rawValue).postMessage('The flow failed during initialization')
+    } else if (component.flowStatus === 'ready' || component.shadowRoot?.querySelector('descope-container')) {
         \(namespace)_ready(component, 'immediate')
     } else {
         component.addEventListener('ready', () => {

--- a/src/flows/FlowView.swift
+++ b/src/flows/FlowView.swift
@@ -157,14 +157,17 @@ open class DescopeFlowView: UIView {
 
     /// Loads and displays a Descope Flow.
     ///
-    /// You can call this method while the view is hidden to prepare the flow ahead of time,
-    /// watching for updates via the delegate, and showing the view when it's ready.
+    /// The ``delegate`` property should be set before calling this function to ensure
+    /// no delegate updates are missed.
     ///
     /// ```swift
     /// let flowURL = URL(string: "https://example.com/myflow")!
     /// let flow = DescopeFlow(url: flowURL)
     /// flowView.start(flow: flow)
     /// ```
+    ///
+    /// You can call this method while the view is hidden to prepare the flow ahead of time,
+    /// watching for updates via the delegate, and showing the view when it's ready.
     public func start(flow: DescopeFlow) {
         coordinator.start(flow: flow)
     }

--- a/src/flows/FlowView.swift
+++ b/src/flows/FlowView.swift
@@ -41,9 +41,6 @@ public protocol DescopeFlowViewDelegate: AnyObject {
     ///
     /// The `response` parameter can be used to create a ``DescopeSession`` as with other
     /// authentication methods.
-    ///
-    /// ```swift
-    /// ```
     func flowViewDidFinishAuthentication(_ flowView: DescopeFlowView, response: AuthenticationResponse)
 }
 
@@ -113,8 +110,6 @@ open class DescopeFlowView: UIView {
     private let coordinator = DescopeFlowCoordinator()
 
     private lazy var webView: WKWebView = createWebView()
-
-    private lazy var delegateWrapper = CoordinatorDelegateWrapper(view: self)
 
     /// A delegate object for receiving events about the state of the flow.
     public weak var delegate: DescopeFlowViewDelegate?
@@ -219,6 +214,8 @@ open class DescopeFlowView: UIView {
 
     // Delegation points (not public for now)
 
+    private lazy var delegateWrapper = CoordinatorDelegateWrapper(view: self)
+
     func didUpdateState(to state: DescopeFlowState, from previous: DescopeFlowState) {
         delegate?.flowViewDidUpdateState(self, to: state, from: previous)
     }
@@ -237,6 +234,13 @@ open class DescopeFlowView: UIView {
 
     func didFinishAuthentication(response: AuthenticationResponse) {
         delegate?.flowViewDidFinishAuthentication(self, response: response)
+    }
+}
+
+/// A custom WKWebView subclass to hide the form navigation bar.
+private class DescopeCustomWebView: WKWebView {
+    override var inputAccessoryView: UIView? {
+        return nil
     }
 }
 
@@ -266,13 +270,6 @@ private class CoordinatorDelegateWrapper: DescopeFlowCoordinatorDelegate {
 
     func coordinatorDidFinishAuthentication(_ coordinator: DescopeFlowCoordinator, response: AuthenticationResponse) {
         view?.didFinishAuthentication(response: response)
-    }
-}
-
-/// A custom WKWebView subclass to hide the form navigation bar.
-private class DescopeCustomWebView: WKWebView {
-    override var inputAccessoryView: UIView? {
-        return nil
     }
 }
 

--- a/src/internal/http/DescopeClient.swift
+++ b/src/internal/http/DescopeClient.swift
@@ -582,11 +582,11 @@ private extension DeliveryMethod {
 private func findTokenCookie(named name: String, in cookies: [HTTPCookie], projectId: String?) throws(DescopeError) -> String {
     // keep only cookies matching the required name
     let cookies = cookies.filter { name.caseInsensitiveCompare($0.name) == .orderedSame }
-    guard !cookies.isEmpty else { throw DescopeError.decodeError.with(message: "Missing value in response \(name) cookie") }
+    guard !cookies.isEmpty else { throw DescopeError.decodeError.with(message: "Missing value for \(name) cookie") }
 
     // try to make a deterministic choice between cookies by looking for the best matching token
     var tokens = cookies.compactMap { try? Token(jwt: $0.value) }
-    guard !tokens.isEmpty else { throw DescopeError.decodeError.with(message: "Invalid value in response \(name) cookie") }
+    guard !tokens.isEmpty else { throw DescopeError.decodeError.with(message: "Invalid value for \(name) cookie") }
 
     // try to find the best match by prioritizing the newest non-expired token
     tokens = tokens.sorted { a, b in
@@ -599,7 +599,7 @@ private func findTokenCookie(named name: String, in cookies: [HTTPCookie], proje
         tokens = tokens.filter { $0.projectId == projectId }
     }
 
-    guard let token = tokens.first else { throw DescopeError.decodeError.with(message: "Unexpected token issuer in response \(name) cookie") }
+    guard let token = tokens.first else { throw DescopeError.decodeError.with(message: "Unexpected issuer in \(name) cookie") }
 
     return token.jwt
 }

--- a/src/sdk/SDK.swift
+++ b/src/sdk/SDK.swift
@@ -128,7 +128,7 @@ public extension DescopeSDK {
     static let name = "DescopeKit"
     
     /// The Descope SDK version
-    static let version = "0.9.7"
+    static let version = "0.9.8"
 }
 
 // Internal

--- a/test/http/JWTResponse.swift
+++ b/test/http/JWTResponse.swift
@@ -1,0 +1,93 @@
+
+import XCTest
+@testable import DescopeKit
+
+class TestJWTResponse: XCTestCase {
+    let descope = DescopeSDK.mock()
+
+    func testNoRefreshJWT() async throws {
+        MockHTTP.push(body: authPayload)
+        do {
+            _ = try await descope.otp.verify(with: .email, loginId: "foo", code: "123456")
+            XCTFail("Expected failure")
+        } catch { /* ok */ }
+    }
+
+    func testCookieRefreshJWT() async throws {
+        MockHTTP.push(body: authPayload, headers: ["Set-Cookie": cookiePayload])
+        let authResponse = try await descope.otp.verify(with: .email, loginId: "foo", code: "123456")
+        XCTAssertEqual("bar", authResponse.sessionToken.entityId)
+        XCTAssertEqual("qux", authResponse.refreshToken.entityId)
+    }
+
+    func testPageCookie() async throws {
+        let data = Data(authPayload.utf8)
+
+        let validCookie = HTTPCookie(properties: [.name: "DSR", .path: "/", .domain: "example.com", .value: refreshJwt])!
+        let expiredCookie = HTTPCookie(properties: [.name: "DSR", .path: "/", .domain: "example.com", .value: expiredJwt])!
+        let newestCookie = HTTPCookie(properties: [.name: "DSR", .path: "/", .domain: "example.com", .value: newestJwt])!
+
+        // should find a valid refresh jwt for the right project
+        var jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
+        try jwtResponse.setValues(from: data, cookies: [validCookie], projectId: "foo")
+        var authResponse: AuthenticationResponse = try jwtResponse.convert()
+        XCTAssertFalse(authResponse.refreshToken.isExpired)
+
+        // should fail because the project doesn't match the issuer
+        jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
+        do {
+            try jwtResponse.setValues(from: data, cookies: [validCookie], projectId: "bar")
+            XCTFail("Expected failure")
+        } catch { /* ok */ }
+
+        // should succeed but return an expired JWT since that's all we've got
+        jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
+        try jwtResponse.setValues(from: data, cookies: [expiredCookie], projectId: "foo")
+        authResponse = try jwtResponse.convert()
+        XCTAssertTrue(authResponse.refreshToken.isExpired)
+
+        // should succeed and find the non-expired JWT (order shouldn't matter)
+        for v in [[expiredCookie, validCookie], [validCookie, expiredCookie]] {
+            jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
+            try jwtResponse.setValues(from: data, cookies: v, projectId: "foo")
+            authResponse = try jwtResponse.convert()
+            XCTAssertFalse(authResponse.refreshToken.isExpired)
+        }
+
+        // should pick the newest JWT out of all valid ones (order shouldn't matter)
+        for v in [[expiredCookie, validCookie, newestCookie], [newestCookie, expiredCookie, validCookie], [validCookie, expiredCookie, newestCookie]] {
+            jwtResponse = try JSONDecoder().decode(DescopeClient.JWTResponse.self, from: data)
+            try jwtResponse.setValues(from: data, cookies: v, projectId: "foo")
+            authResponse = try jwtResponse.convert()
+            XCTAssertFalse(authResponse.refreshToken.isExpired)
+            XCTAssertEqual(authResponse.refreshToken.issuedAt, Date(timeIntervalSince1970: 1526239022))
+        }
+    }
+}
+
+private let cookiePayload = "DSR=\(refreshJwt); Path=/; Expires=Thu, 02 Jan 2025 10:01:41 GMT; Max-Age=2419199; HttpOnly; Secure; SameSite=None"
+
+private let authPayload = """
+{
+    "sessionJwt": "\(sessionJwt)",
+    "refreshJwt": "",
+    "user": \(userPayload),
+    "firstSeen": true
+}
+"""
+
+private let userPayload = """
+{
+    "userId": "userId",
+    "loginIds": ["foo"],
+    "email": "email",
+    "verifiedEmail": true,
+    "createdTime": 123,
+    "customAttributes": {}
+}
+"""
+
+private let sessionJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJiYXIiLCJuYW1lIjoiU3dpZnR5IE1jQXBwbGVzIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJmb28iLCJleHAiOjE2MDMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0.LEcNdzkdOXlzxcVNhvlqOIoNwzgYYfcDv1_vzF3awF8"
+private let refreshJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJxdXgiLCJuYW1lIjoiU3dpZnR5IE1jQXBwbGVzIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJmb28iLCJleHAiOjIxMDMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0.ihTyqWzhdtBwjjyyJ-E5_wOVkHqBHxEtnpPGr848vYI"
+private let expiredJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJxdXgiLCJuYW1lIjoiU3dpZnR5IE1jQXBwbGVzIiwiaWF0IjoxNTE2MjM5MDIyLCJpc3MiOiJmb28iLCJleHAiOjE1MjMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0.ICHASqOp7uDiknXu6eINSKLMnixND3-OIAww9ZCN7qs"
+private let newestJwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJxdXgiLCJuYW1lIjoiU3dpZnR5IE1jQXBwbGVzIiwiaWF0IjoxNTI2MjM5MDIyLCJpc3MiOiJmb28iLCJleHAiOjIxMDMxNzY2MTQsInBlcm1pc3Npb25zIjpbImQiLCJlIl0sInJvbGVzIjpbInVzZXIiXSwidGVuYW50cyI6eyJ0ZW5hbnQiOnsicGVybWlzc2lvbnMiOlsiYSIsImIiLCJjIl0sInJvbGVzIjpbImFkbWluIl19fX0.rgnEi7rxuGEAFiWUrZnyXJvWX8giNQpiBBVVtMwHLZo"


### PR DESCRIPTION
## Related PRs
https://github.com/descope/swift-sdk/pull/74

## Description
- Disable two finger and double tap zoom gestures by default when presenting native flows
- Refactor `JWTResponse` cookie handling code and add unit tests
- Ensure only cookies for the correct domain of the flow are used for the `JWTResponse` tokens
- Use new web-component API for checking status
- Update and cleanup documentation

## Must
- [X] Tests
- [X] Documentation (if applicable)

